### PR TITLE
Add TravisCI to the project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: go
+go:
+  - 1.7.4


### PR DESCRIPTION
By default, Travis will test Go projects.