### PR TITLE
Use SemVer. Expose /version endpoint

### DIFF
--- a/handlers/version.go
+++ b/handlers/version.go
@@ -1,0 +1,30 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// VersionResponse ...
+type VersionResponse struct {
+	Version string `json:"version"`
+}
+
+type versionHandler struct {
+	version string
+}
+
+func (h *versionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	response := VersionResponse{
+		Version: h.version,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(response)
+}
+
+// VersionHandler ...
+func VersionHandler(version string) http.Handler {
+	return &versionHandler{
+		version: version,
+	}
+}

--- a/handlers/version_test.go
+++ b/handlers/version_test.go
@@ -1,0 +1,48 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestVersionHandler(t *testing.T) {
+	version := "test-version"
+
+	// Create a request to pass to our handler.
+	// We don't have any query parameters, hence why we use 'nil' as 3rd parameter
+	req, err := http.NewRequest("GET", "/version", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We create a ResponseRecorder (which satisfies http.ResponseWriter)
+	// to record the response.
+	rr := httptest.NewRecorder()
+	handler := http.Handler(VersionHandler(version))
+
+	// Our handlers satisfy http.Handler, so we can call their ServeHTTP method
+	// directly and pass in our Request and ResponseRecorder
+	handler.ServeHTTP(rr, req)
+
+	// Check the status code is what we expect.
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+	}
+
+	// Check the Content-Type is what we expect.
+	if ctype := rr.Header().Get("Content-Type"); ctype != "application/json" {
+		t.Errorf("content type header does not match: got %v want %v",
+			ctype, "application/json")
+	}
+
+	// Check the response body is what we expect.
+	expected := fmt.Sprintf("{\"version\":\"%s\"}\n", version)
+	if rr.Body.String() != expected {
+		t.Errorf("handler returned unexpected body: got %v want %v",
+			rr.Body.String(), expected)
+	}
+
+}

--- a/main.go
+++ b/main.go
@@ -1,7 +1,19 @@
 package main
 
-import "log"
+import (
+	"log"
+	"net/http"
+
+	"github.com/jvrplmlmn/nginx-requests-stats/handlers"
+)
+
+const version = "0.1.0"
 
 func main() {
 	log.Println("Starting 'nginx-requests-stats' app...")
+
+	// This endpoint returns a JSON with the version of the application
+	http.Handle("/version", handlers.VersionHandler(version))
+	log.Fatal(http.ListenAndServe("localhost:8080", nil))
+
 }


### PR DESCRIPTION
- Set the current version to 0.1.0 (follows [Semantic Versioning](http://semver.org/)).
- Adds a `handlers` package that includes a HTTP handler that returns a JSON with the application version.
- Expose the `/version` endpoint.